### PR TITLE
add uid option to s3fs and allow "=" in sshpubkey

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -58,7 +58,7 @@ main() {
             OPTION_SSHUSER="${VALUE}"
             ;;
         --sshpubkey)
-            OPTION_SSHPUBKEY="${VALUE}"
+            OPTION_SSHPUBKEY="${VALUE//_/=}"
             ;;
         *)
             echo "ERROR: unknown parameter \"$PARAM\""
@@ -97,6 +97,7 @@ main() {
 
   log "Create user ${SSHUSER}"
   useradd -m -s /bin/false "${SSHUSER}" || err "Fail to create ${SSHUSER}"
+  USERID=$(id -u "$SSHUSER")
 
   log "Create ssh directory in user home"
   mkdir -vp "/home/${SSHUSER}/.ssh/" || err "Failed to create dir"
@@ -110,9 +111,9 @@ main() {
   chown -R "${SSHUSER}:${SSHUSER}" "/home/${SSHUSER}"
 
   log "Mount s3 bucket"
-  echo s3fs "${S3BUCKETNAME}:${S3BUCKETPATH}" "/mnt/${S3BUCKETNAME}" -f -o "${S3FSOPTIONS}"
+  echo s3fs "${S3BUCKETNAME}:${S3BUCKETPATH}" "/mnt/${S3BUCKETNAME}" -f -o "${S3FSOPTIONS}" -o uid="${USERID}"
   mkdir -p "/mnt/${S3BUCKETNAME}"
-  s3fs "${S3BUCKETNAME}:${S3BUCKETPATH}" "/mnt/${S3BUCKETNAME}" -f -o "${S3FSOPTIONS}" &
+  s3fs "${S3BUCKETNAME}:${S3BUCKETPATH}" "/mnt/${S3BUCKETNAME}" -f -o "${S3FSOPTIONS}" -o uid="${USERID}" &
   S3FS_PID=$!
 
   log "Start sshd daemon"


### PR DESCRIPTION
This PR adds the `uid` parameter to s3fs, this will ensure that the sshuser has access to the filesystem.
Further, `=` in the parameter sshpubkey would currently not work - to fix this, I'm now replacing any `_` char in the pub key (which should not occur normally) with `=` so that you can workaround this.